### PR TITLE
Update node version

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -19,7 +19,7 @@ outputs:
   package_suffix:
     description: 'If the action is triggered on a non-default branch its assumed to be a prerelease and the suffix will be the branch name. Otherwise it will be an empty string.'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: bookmark


### PR DESCRIPTION
Hi, Node16 has reached end-of-life and Github will require node20 by Spring 2024

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/